### PR TITLE
List all nodes of a service

### DIFF
--- a/cmd/pprof-server/main.go
+++ b/cmd/pprof-server/main.go
@@ -62,6 +62,7 @@ func main() {
 			events.Log("no registry is configured")
 		case "consul":
 			consul.DefaultClient.Address = u.Host
+			consul.DefaultResolver.Balancer = nil
 			registry = &pprofserver.ConsulRegistry{}
 			events.Log("using consul registry at %{address}s", u.Host)
 		default:

--- a/consul.go
+++ b/consul.go
@@ -25,6 +25,20 @@ func (r *ConsulRegistry) ListServices(ctx context.Context) ([]string, error) {
 	return list, nil
 }
 
-func (r *ConsulRegistry) LookupService(ctx context.Context, name string) ([]string, error) {
-	return consul.LookupHost(ctx, name)
+func (r *ConsulRegistry) LookupService(ctx context.Context, name string) (Service, error) {
+	svc := Service{}
+
+	endpoints, err := consul.LookupService(ctx, name)
+	if err != nil {
+		return svc, err
+	}
+
+	svc.Hosts = make([]Host, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		svc.Hosts = append(svc.Hosts, Host{
+			Addr: endpoint.Addr,
+			Tags: endpoint.Tags,
+		})
+	}
+	return svc, nil
 }

--- a/html.go
+++ b/html.go
@@ -37,6 +37,31 @@ var lookupService = htmlTemplate(`
 </html>
 `)
 
+var listNodes = htmlTemplate(`
+<html>
+<head>
+	<title>{{ .Name }}</title>
+</head>
+<body>
+	<p>
+		<a href="/services">&lt;&lt; Services</a>
+	</p>
+	<table>
+		<th>
+			<tr>
+				<td>Nodes</td>
+			</tr>
+		</th>
+		<tbody>{{ range .Nodes }}
+			<tr>
+				<td><a href="{{ .Href }}">{{ .Endpoint }}</a></td>
+			</tr>
+		{{ end }}</tbody>
+	</table>
+</body>
+</html>
+`)
+
 func htmlTemplate(s string) *template.Template {
 	return template.Must(template.New("").Parse(s))
 }

--- a/registry.go
+++ b/registry.go
@@ -1,1 +1,21 @@
 package pprofserver
+
+import (
+	"context"
+	"net"
+)
+
+type Service struct {
+	Name  string
+	Hosts []Host
+}
+
+type Host struct {
+	Addr net.Addr
+	Tags []string
+}
+
+type Registry interface {
+	ListServices(ctx context.Context) ([]string, error)
+	LookupService(ctx context.Context, name string) (Service, error)
+}


### PR DESCRIPTION
Just remembered I have that change seating in a branch. Really simple change which adds an endpoint for each nodes of a service and remove the RR Consul balancer to fetch all the nodes.

There is thousand ways of thinking and building the rendering so I went to the simplest one.

If I have more time to spend on it I will fetch tags for each `node` and write some tests.