### PR TITLE
[SRE-1774] upgrade Go to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.6
+FROM golang:1.17.0
 
 RUN apt-get update -y && \
     apt-get install -y ca-certificates graphviz


### PR DESCRIPTION
This should solve some of the security issues and bring any changes to profile rendering available in newer Go versions.

There are still three high risk vulnerabilities in the latest Debian base image that have no fixes yet:

```
✗ High severity vulnerability found in python3.9/libpython3.9-stdlib
  Description: Improper Input Validation
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-PYTHON39-1290158
  Introduced through: mercurial@5.6.1-4
  From: mercurial@5.6.1-4 > python3-defaults/python3@3.9.2-3 > python3-defaults/libpython3-stdlib@3.9.2-3 > python3.9/libpython3.9-stdlib@3.9.2-1
  From: mercurial@5.6.1-4 > python3-defaults/python3@3.9.2-3 > python3.9@3.9.2-1 > python3.9/libpython3.9-stdlib@3.9.2-1
  From: mercurial@5.6.1-4 > python3-defaults/python3@3.9.2-3 > python3-defaults/python3-minimal@3.9.2-3 > python3.9/python3.9-minimal@3.9.2-1
  and 4 more...

✗ High severity vulnerability found in glibc/libc-dev-bin
  Description: Use After Free
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-GLIBC-1296898
  Introduced through: gcc-defaults/g++@4:10.2.1-1, glibc/libc6-dev@2.31-13, glibc/libc-bin@2.31-13, meta-common-packages@meta
  From: gcc-defaults/g++@4:10.2.1-1 > gcc-10/g++-10@10.2.1-6 > gcc-10/libstdc++-10-dev@10.2.1-6 > glibc/libc6-dev@2.31-13 > glibc/libc-dev-bin@2.31-13
  From: glibc/libc6-dev@2.31-13
  From: gcc-defaults/g++@4:10.2.1-1 > gcc-10/g++-10@10.2.1-6 > gcc-10/libstdc++-10-dev@10.2.1-6 > glibc/libc6-dev@2.31-13
  and 2 more...

✗ High severity vulnerability found in curl/libcurl4
  Description: Use of Incorrectly-Resolved Name or Reference
  Info: https://snyk.io/vuln/SNYK-DEBIAN11-CURL-1322658
  Introduced through: curl/curl@7.74.0-1.3+b1, git@1:2.30.2-1
  From: curl/curl@7.74.0-1.3+b1 > curl/libcurl4@7.74.0-1.3+b1
  From: curl/curl@7.74.0-1.3+b1
  From: git@1:2.30.2-1 > curl/libcurl3-gnutls@7.74.0-1.3+b1

```
