### PR TITLE
html: add EKS warning message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
-	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
+	golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	google.golang.org/appengine v1.6.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,9 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t3cHp9ZpwcdjqyEWLlo=
+golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/handler.go
+++ b/handler.go
@@ -25,6 +25,7 @@ type Handler struct {
 }
 
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
+	fmt.Println("in serve http handler")
 	header := res.Header()
 	header.Set("Content-Language", "en")
 	header.Set("Server", "pprof-server")
@@ -38,7 +39,7 @@ func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	switch path := req.URL.Path; {
 	case path == "/", path == "/services":
-		if h.Registry.String() == "kubernetes" {
+		if h.Registry != nil && h.Registry.String() == "kubernetes" {
 			h.serveRedirect(res, req, "/pods/")
 		} else {
 			h.serveRedirect(res, req, "/services/")

--- a/handler.go
+++ b/handler.go
@@ -25,7 +25,6 @@ type Handler struct {
 }
 
 func (h *Handler) ServeHTTP(res http.ResponseWriter, req *http.Request) {
-	fmt.Println("in serve http handler")
 	header := res.Header()
 	header.Set("Content-Language", "en")
 	header.Set("Server", "pprof-server")

--- a/html.go
+++ b/html.go
@@ -6,11 +6,38 @@ var listServices = htmlTemplate("listServices", `
 <html>
 <head>
 	<title>Service List</title>
-	<style>a {text-decoration: none;}</style>
+	<style>
+		.service-list a {
+			text-decoration: none;
+		}
+		
+		/* 
+		 * Alert box styles copied from Bootstrap, which has a MIT license:
+		 * https://github.com/twbs/bootstrap/blob/main/LICENSE
+		 */
+		.alert {
+			position: relative;
+			padding: 0.75rem 1.25rem;
+			margin-bottom: 1rem;
+			border: 1px solid transparent;
+			border-radius: 0.25rem;
+		}
+
+		.alert-danger {
+			color: #721c24;
+			background-color: #f8d7da;
+			border-color: #f5c6cb;
+		}
+	</style>
 </head>
 <body>
-	<ul>{{ range . }}
-		<li><a href="{{ .Href }}">{{ .Name }}</a></li>
+	<div class="alert alert-danger">
+		EKS services are not listed here.<br /><br />
+		Use <a href="https://github.com/segmentio/kubectl-curl#collecting-profiles-of-go-programs">kubectl-curl</a> 
+		to download profiles for EKS services.
+	</div>
+	<ul class="service-list">{{ range . }}
+		<li><a title="{{ .Name }}" href="{{ .Href }}">{{ .Name }}</a></li>
 	{{ end }}</ul>
 </body>
 </html>


### PR DESCRIPTION
Provide a link that explains where to download EKS traces, instead.

go.mod,handler: get service working with Go 1.18

We need to update the x/sys dependency to work with Go 1.18, and also fix a
panic in the handler if h.Registry is nil, so I can view and test changes
to the UI locally.