### PR TITLE
chore: update owner in backstage catalog file

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,4 +12,4 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: sre-compute
+  owner: infra-compute-us


### PR DESCRIPTION
This PR updates the owner of this component in Backstage by updating the owner spec field in the `catalog-info.yaml` file.

The current stated owner doesn't exist in Backstage so we are updating this to a more accurate one.